### PR TITLE
facebook channel connector should allow empty buttons resolve issue #4712

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ This project adheres to `Semantic Versioning`_ starting with version 1.0.
 Added
 -----
 - Added the KeywordIntentClassifier
+- Fall back to ``InMemoryTrackerStore`` in case there is any problem with the current
+  tracker store
 
 Changed
 -------

--- a/rasa/cli/x.py
+++ b/rasa/cli/x.py
@@ -347,7 +347,7 @@ def run_in_production(args: argparse.Namespace):
 
 
 def _get_credentials_and_endpoints_paths(
-    args: argparse.Namespace
+    args: argparse.Namespace,
 ) -> Tuple[Optional[Text], Optional[Text]]:
     config_endpoint = args.config_endpoint
     if config_endpoint:

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -831,20 +831,13 @@ class Agent(object):
             message_preprocessor=preprocessor,
         )
 
-    def on_tracker_store_error(self, error: Exception):
+    def on_tracker_store_error(self, error: Exception) -> None:
         logger.error(
             f"Error happened when trying to save conversation tracker to "
             f"'{self.tracker_store.__class__.__name__}'. Falling back to use "
-            f"{InMemoryTrackerStore.__class__.__name__}. Please "
+            f"the '{InMemoryTrackerStore.__name__}'. Please "
             f"investigate the following error: {error}."
         )
-
-        # Initialise fallback tracker store to keep Rasa functional
-        self.tracker_store = InMemoryTrackerStore(
-            self.domain, self.tracker_store.event_broker
-        )
-
-        return self.tracker_store
 
     @staticmethod
     def _create_domain(domain: Union[Domain, Text]) -> Domain:

--- a/rasa/core/agent.py
+++ b/rasa/core/agent.py
@@ -831,14 +831,6 @@ class Agent(object):
             message_preprocessor=preprocessor,
         )
 
-    def on_tracker_store_error(self, error: Exception) -> None:
-        logger.error(
-            f"Error happened when trying to save conversation tracker to "
-            f"'{self.tracker_store.__class__.__name__}'. Falling back to use "
-            f"the '{InMemoryTrackerStore.__name__}'. Please "
-            f"investigate the following error: {error}."
-        )
-
     @staticmethod
     def _create_domain(domain: Union[Domain, Text]) -> Domain:
 
@@ -857,8 +849,9 @@ class Agent(object):
                 "type '{}' with value '{}'".format(type(domain), domain)
             )
 
+    @staticmethod
     def create_tracker_store(
-        self, store: Optional[TrackerStore], domain: Domain
+        store: Optional[TrackerStore], domain: Domain
     ) -> TrackerStore:
         if store is not None:
             store.domain = domain
@@ -866,7 +859,7 @@ class Agent(object):
         else:
             tracker_store = InMemoryTrackerStore(domain)
 
-        return FailSafeTrackerStore(tracker_store, self.on_tracker_store_error)
+        return FailSafeTrackerStore(tracker_store)
 
     @staticmethod
     def _create_lock_store(store: Optional[LockStore]) -> LockStore:

--- a/rasa/core/processor.py
+++ b/rasa/core/processor.py
@@ -578,7 +578,7 @@ class MessageProcessor(object):
         sender_id = sender_id or UserMessage.DEFAULT_SENDER_ID
         return self.tracker_store.get_or_create_tracker(sender_id)
 
-    def _save_tracker(self, tracker):
+    def _save_tracker(self, tracker: DialogueStateTracker) -> None:
         self.tracker_store.save(tracker)
 
     def _prob_array_for_action(

--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -587,7 +587,6 @@ async def compare_models_in_dir(
     model_dir: Text, stories_file: Text, output: Text
 ) -> None:
     """Evaluates multiple trained models in a directory on a test set."""
-    from rasa.core import utils
     import rasa.utils.io as io_utils
 
     number_correct = defaultdict(list)
@@ -615,7 +614,6 @@ async def compare_models_in_dir(
 
 async def compare_models(models: List[Text], stories_file: Text, output: Text) -> None:
     """Evaluates provided trained models on a test set."""
-    from rasa.core import utils
 
     number_correct = defaultdict(list)
 

--- a/rasa/core/tracker_store.py
+++ b/rasa/core/tracker_store.py
@@ -57,10 +57,10 @@ class TrackerStore(object):
                 )
             except Exception as e:
                 logger.error(
-                    f"Error when trying to connect to {store.type} "
+                    f"Error when trying to connect to '{store.type}' "
                     f"tracker store. Using "
-                    f"{InMemoryTrackerStore.__class__.__name__} instead. "
-                    f"The causing error was {e}."
+                    f"'{InMemoryTrackerStore.__name__}'' instead. "
+                    f"The causing error was: {e}."
                 )
 
         if not tracker_store:

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -319,29 +319,26 @@ def test_fail_safe_tracker_store_with_save_error():
     fallback_tracker_store = Mock()
     fallback_tracker_store.save = Mock()
 
-    def error_callback(_):
-        return fallback_tracker_store
+    on_error_callback = Mock()
 
-    tracker_store = FailSafeTrackerStore(mocked_tracker_store, error_callback)
+    tracker_store = FailSafeTrackerStore(
+        mocked_tracker_store, on_error_callback, fallback_tracker_store
+    )
     tracker_store.save(None)
 
-    assert tracker_store.tracker_store == fallback_tracker_store
     fallback_tracker_store.save.assert_called_once()
+    on_error_callback.assert_called_once()
 
 
 def test_fail_safe_tracker_store_with_keys_error():
     mocked_tracker_store = Mock()
     mocked_tracker_store.keys = Mock(side_effect=Exception())
 
-    fallback_tracker_store = Mock()
+    on_error_callback = Mock()
 
-    def error_callback(_):
-        return fallback_tracker_store
-
-    tracker_store = FailSafeTrackerStore(mocked_tracker_store, error_callback)
+    tracker_store = FailSafeTrackerStore(mocked_tracker_store, on_error_callback)
     assert tracker_store.keys() == []
-
-    assert tracker_store.tracker_store == fallback_tracker_store
+    on_error_callback.assert_called_once()
 
 
 def test_fail_safe_tracker_store_with_retrieve_error():
@@ -349,11 +346,11 @@ def test_fail_safe_tracker_store_with_retrieve_error():
     mocked_tracker_store.retrieve = Mock(side_effect=Exception())
 
     fallback_tracker_store = Mock()
+    on_error_callback = Mock()
 
-    def error_callback(_):
-        return fallback_tracker_store
-
-    tracker_store = FailSafeTrackerStore(mocked_tracker_store, error_callback)
+    tracker_store = FailSafeTrackerStore(
+        mocked_tracker_store, on_error_callback, fallback_tracker_store
+    )
 
     assert tracker_store.retrieve("sender_id") is None
-    assert tracker_store.tracker_store == fallback_tracker_store
+    on_error_callback.assert_called_once()

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -1,6 +1,6 @@
 import logging
 import tempfile
-from typing import Tuple
+from typing import Tuple, Text
 from unittest.mock import Mock
 
 import pytest
@@ -53,7 +53,7 @@ def test_dynamo_get_or_create():
     get_or_create_tracker_store(DynamoTrackerStore(domain))
 
 
-def test_restart_after_retrieval_from_tracker_store(default_domain):
+def test_restart_after_retrieval_from_tracker_store(default_domain: Domain):
     store = InMemoryTrackerStore(default_domain)
     tr = store.get_or_create_tracker("myuser")
     synth = [ActionExecuted("action_listen") for _ in range(4)]
@@ -70,7 +70,7 @@ def test_restart_after_retrieval_from_tracker_store(default_domain):
     assert latest_restart == latest_restart_after_loading
 
 
-def test_tracker_store_remembers_max_history(default_domain):
+def test_tracker_store_remembers_max_history(default_domain: Domain):
     store = InMemoryTrackerStore(default_domain)
     tr = store.get_or_create_tracker("myuser", max_event_history=42)
     tr.update(Restarted())
@@ -135,7 +135,7 @@ class ExampleTrackerStore(RedisTrackerStore):
         )
 
 
-def test_tracker_store_from_string(default_domain):
+def test_tracker_store_from_string(default_domain: Domain):
     endpoints_path = "data/test_endpoints/custom_tracker_endpoints.yml"
     store_config = read_endpoint_config(endpoints_path, "tracker_store")
 
@@ -144,7 +144,7 @@ def test_tracker_store_from_string(default_domain):
     assert isinstance(tracker_store, ExampleTrackerStore)
 
 
-def test_tracker_store_from_invalid_module(default_domain):
+def test_tracker_store_from_invalid_module(default_domain: Domain):
     endpoints_path = "data/test_endpoints/custom_tracker_endpoints.yml"
     store_config = read_endpoint_config(endpoints_path, "tracker_store")
     store_config.type = "a.module.which.cannot.be.found"
@@ -154,7 +154,7 @@ def test_tracker_store_from_invalid_module(default_domain):
     assert isinstance(tracker_store, InMemoryTrackerStore)
 
 
-def test_tracker_store_from_invalid_string(default_domain):
+def test_tracker_store_from_invalid_string(default_domain: Domain):
     endpoints_path = "data/test_endpoints/custom_tracker_endpoints.yml"
     store_config = read_endpoint_config(endpoints_path, "tracker_store")
     store_config.type = "any string"
@@ -220,7 +220,7 @@ def test_deprecated_pickle_deserialisation(caplog: LogCaptureFixture):
         "postgresql://user:secret@localhost",
     ],
 )
-def test_get_db_url_with_fully_specified_url(full_url):
+def test_get_db_url_with_fully_specified_url(full_url: Text):
     assert SQLTrackerStore.get_db_url(host=full_url) == full_url
 
 

--- a/tests/core/test_tracker_stores.py
+++ b/tests/core/test_tracker_stores.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 from _pytest.logging import LogCaptureFixture
+from _pytest.monkeypatch import MonkeyPatch
 from moto import mock_dynamodb2
 
 from rasa.core.channels.channel import UserMessage
@@ -94,7 +95,7 @@ def test_tracker_store_endpoint_config_loading():
     )
 
 
-def test_find_tracker_store(default_domain):
+def test_find_tracker_store(default_domain: Domain):
     store = read_endpoint_config(DEFAULT_ENDPOINTS_FILE, "tracker_store")
     tracker_store = RedisTrackerStore(
         domain=default_domain,
@@ -107,6 +108,17 @@ def test_find_tracker_store(default_domain):
 
     assert isinstance(
         tracker_store, type(TrackerStore.find_tracker_store(default_domain, store))
+    )
+
+
+def test_find_tracker_store(default_domain: Domain, monkeypatch: MonkeyPatch):
+    store = read_endpoint_config(DEFAULT_ENDPOINTS_FILE, "tracker_store")
+    mock = Mock(side_effect=Exception("ignore this"))
+    monkeypatch.setattr(rasa.core.tracker_store, "RedisTrackerStore", mock)
+
+    assert isinstance(
+        InMemoryTrackerStore(domain),
+        type(TrackerStore.find_tracker_store(default_domain, store)),
     )
 
 


### PR DESCRIPTION
**Proposed changes**:
As buttons are optional for facebooks generic templates, the channel connector should allow None for button attribute within element.

The proposed change skips the process of adding a type for each button whenever the list is None.


**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa_nlu#code-style) for instructions)
